### PR TITLE
[tmp] fast_csr_matrix replacement

### DIFF
--- a/qutip/core/data/__init__.py
+++ b/qutip/core/data/__init__.py
@@ -1,3 +1,6 @@
+from . import dense
+from . import csr
+
 from .dense import Dense
 from .csr import CSR
 from .base import Data
@@ -13,3 +16,18 @@ from .properties import *
 from .reshape import *
 from .sub import *
 from .trace import *
+
+
+# This is completely temporary - it will actually get replaced by a proper
+# dispatcher in its own module, but for now I'm just trying to get CSR working
+# within Qobj, and this is the fastest way to stub out this creation.
+
+def create(arg):
+    import numpy as np
+    import scipy.sparse
+
+    if isinstance(arg, CSR):
+        return arg.copy()
+    if scipy.sparse.issparse(arg):
+        return CSR(arg.tocsr())
+    return CSR(scipy.sparse.csr_matrix(np.array(arg)))

--- a/qutip/rcsolve.py
+++ b/qutip/rcsolve.py
@@ -47,7 +47,7 @@ from numpy import matrix
 from numpy import linalg
 from . import (
     spre, spost, sprepost, thermal_dm, mesolve, Options, tensor, identity,
-    destroy, sigmax, sigmaz, basis, qeye, dims,
+    destroy, sigmax, sigmaz, basis, qeye,
 )
 
 
@@ -102,7 +102,7 @@ def rcsolve(Hsys, psi0, tlist, e_ops, Q, wc, alpha, N, w_th, sparse=False,
 
     # Reaction coordinate hamiltonian/operators
 
-    dimensions = dims(Q)
+    dimensions = Q.dims
     a = tensor(destroy(N), qeye(dimensions[1]))
     unit = tensor(qeye(N), qeye(dimensions[1]))
     Nmax = N * dimensions[1][0]


### PR DESCRIPTION
This is just a draft showing the differences so far - it's not even a proper commit, but I had to actual create an object to push to GitHub.  This commit will actually be several once I've finished it, and several parts will still probably change.

This will build and import, but won't pass the tests yet - it's nowhere near a complete switch over to the new type, but I've done a good chunk of it.

## Improving timings

I've _started_ to enforce a separation of concerns between the data layer, but not entirely yet.  The biggest change is that `Qobj` is now much stricter about enforcing correct dimensions and type interactions.  This actually makes the code _way_ shorter, and `Qobj` operations like multiplication, addition and matrix multiplication now have massively reduced overheads.  For large systems obviously this doesn't make a huge amount of difference, but qubit spaces have a huge speed boost.  Examples (`qutip` is this branch, `qutip0` is the current `master`):

```
In [1]: import qutip, qutip0
   ...: qi = qutip.qeye(2)
   ...: qi0 = qutip0.qeye(2)

In [2]: %timeit qi * qi
   ...: %timeit qi0 * qi0
30.5 µs ± 54.8 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
71.7 µs ± 179 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [3]: %timeit 2 * qi
   ...: %timeit 2 * qi0
6.81 µs ± 44.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
55 µs ± 329 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [4]: %timeit 1 + qi
   ...: %timeit 1 + qi0
12 µs ± 113 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
513 µs ± 4.62 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [5]: %timeit qi + qi
   ...: %timeit qi0 + qi0
5.97 µs ± 18.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
111 µs ± 647 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

Matrix multiplication should actually be faster than 30µs, but it's currently slow because I haven't passed `'type'` to the `Qobj` constructor afterwards, so it spends ~25µs inferring the type of the object on initialisation.  There may not be a way to avoid this with matrix multiplication, but it's a clear source of slow-down in `Qobj` initialisation, so it's a prime target for getting an optimised Cython backing.

## Matrix multiplication

The most major change that I've made here that actually needs to be discussed is the changes to dimension handling in `__mul__`.  For one, I split the code handling `__mul__` into two parts:

1. `__mul__` handles multiplication with a scalar
2. `__matmul__` handles actual matrix multiplication

I haven't actually changed which operator you need - you can still do `Qobj * Qobj` and it'll do matrix multiplication.  I just split the code into two places so it's easier to reason about.  As a side effect, you can also do `Qobj @ Qobj` now too, but it's not necessary.  We can also talk about what we want to do about the dimension handling in `__mul__` and `__matmul__`.  Right now, it checks for dimensions after the multiplication for [1, 1] and removes any it finds.  This isn't entirely consistent, especially with handling spaces that went _in_ as 1D.  I think we should change it, and there's two possible ways:

1. Completely remove this handling, and just have `__matmul__('bra', 'ket')` return a scalar, everything else follows the normal rules.
2. Keep the handling as it is, but change its logic so that a space has to _become_ `[1, 1]` to be contracted.

I think method 1 is much simpler for most people - you no longer have to do anything like `(bra * ket).data[0, 0]` or `(bra * ket).norm()` to get the value (although of course you can always use `bra.overlap(ket)` which is faster!).  Method 2 is _somewhat_ better with handling 1D spaces than the current method, except if you have lots of them tensored together, some of which are `'oper'` and some of which aren't.  The advantage of method 2 over method 1 is that you can do (say)
```
>>> state = qutip.basis([2]*3, [0]*3)  # dims=[[2, 2, 2], [1, 1, 1]], type='ket'
>>> contractor = qutip.tensor(qutip.qeye(2), qutip.basis(2, 0).dag(), qutip.qeye(2))
>>> contractor * state
Quantum object: dims = [[2, 2], [1, 1]], shape = (4, 1), type = ket
Qobj data = ...
```
so I can define an object like `X = I.<g| .I` and a state `|y> = |g>.|g>.|g>`, i.e. a state on `H_2^3`, and `X|y>` is now a state on `H_2^2`.  I think the main argument against method 1 is that there isn't currently a nice way to do this kind of operation - you'd have to do something like `X = I . |g><g| . I`, then `(X * y).ptrace([0, 2])`.

We could also just have it both ways.  We can pick a way we like and bind that to `__mul__` (I'd suggest method 1 for this because its logic is more consistent), and have `__matmul__` do the other.  Then you have `*` is the default multiplication operator, and `@` is the "contracting" multiplication operator (and have a setting for which is which).